### PR TITLE
Update 02-nfl-analytics-tidyverse.qmd

### DIFF
--- a/02-nfl-analytics-tidyverse.qmd
+++ b/02-nfl-analytics-tidyverse.qmd
@@ -580,7 +580,7 @@ airyards_cpoe_mutate <- pbp %>%
       air_yards >= 10 & air_yards < 20 ~ "Medium",
       air_yards >= 20 ~ "Deep")) %>%
   group_by(passer, ay_distance) %>%
-  summarize(avg_cpoe = mean(cpoe))
+  summarize(avg_cpoe = mean(cpoe), .groups = 'drop')
 ```
 
 With the `air_yards` data now binned into four different groupings, we can examine quarterbacks at specific distances.


### PR DESCRIPTION
added the group drop so the tibble produced from the code chunk on line 590 - 593 shows the 10 highest avg cpoe instead of first 10 players